### PR TITLE
Fix a tag event listener on external pages

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -28,10 +28,12 @@
 	});
 
 	$("a[href*=\\#]").on("click", function (event) {
-		event.preventDefault();
+		if(this.pathname === window.location.pathname) {
+			event.preventDefault();
 
-		$("html, body").animate({
-			scrollTop: $(this.hash).offset().top
-		}, 500);
+			$("html, body").animate({
+				scrollTop: $(this.hash).offset().top
+			}, 500);
+		}
 	});
 })();


### PR DESCRIPTION
The scrolling behavior being implemented in this function causes anchor tags to outside pages to break. For example, in my case I was linking to a section on another page on my site like so: `<a href="/contact/#contact">Link to contact page, contact form section</a>`

Implementing this if statement will add a check that will allow this behavior to work, whereas it previously shot a console error. It still retains the original scrolling animation functionality for anchor tags inside the same page.

Test this out and implement it, should be pretty straightforward. Had me stumped for a few minutes.